### PR TITLE
security dependency fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -613,7 +613,7 @@
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
             "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "yargs-parser": ">=13.1.2"
           }
         }
       }


### PR DESCRIPTION
Upgrade yargs-parser to version 13.1.2 or later. 